### PR TITLE
Update Jamfile.v2

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -3,7 +3,7 @@
 #   Distributed under the Boost Software License, Version 1.0.
 #   (See accompanying file LICENSE_1_0.txt or copy at
 #   http://www.boost.org/LICENSE_1_0.txt)
-project boost/doc ;
+project function/doc ;
 import boostbook : boostbook ;
 
 boostbook function-doc 


### PR DESCRIPTION
There can be only one project named boost/doc - and we already have that under doc/
This fixes the PDF doc build.
