### PR TITLE
Remove dependency on deprecated type_traits headers.

### DIFF
--- a/include/boost/function/function_base.hpp
+++ b/include/boost/function/function_base.hpp
@@ -25,9 +25,10 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_volatile.hpp>
 #include <boost/type_traits/composite_traits.hpp>
-#include <boost/type_traits/ice.hpp>
 #include <boost/ref.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/mpl/logical.hpp>
+#include <boost/mpl/not.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/type_traits/alignment_of.hpp>
 #ifndef BOOST_NO_SFINAE
@@ -74,15 +75,15 @@
 
 #if !BOOST_WORKAROUND(__BORLANDC__, < 0x5A0)
 #  define BOOST_FUNCTION_ENABLE_IF_NOT_INTEGRAL(Functor,Type)              \
-      typename ::boost::enable_if_c<(::boost::type_traits::ice_not<          \
-                            (::boost::is_integral<Functor>::value)>::value), \
+      typename ::boost::enable_if<typename ::boost::mpl::not_<          \
+                            ::boost::is_integral<Functor> >::type, \
                            Type>::type
 #else
 // BCC doesn't recognize this depends on a template argument and complains
 // about the use of 'typename'
 #  define BOOST_FUNCTION_ENABLE_IF_NOT_INTEGRAL(Functor,Type)     \
-      ::boost::enable_if_c<(::boost::type_traits::ice_not<          \
-                   (::boost::is_integral<Functor>::value)>::value), \
+      ::boost::enable_if<::boost::mpl::not_<          \
+                   ::boost::is_integral<Functor> >::type, \
                        Type>::type
 #endif
 

--- a/include/boost/function/function_base.hpp
+++ b/include/boost/function/function_base.hpp
@@ -27,7 +27,6 @@
 #include <boost/type_traits/composite_traits.hpp>
 #include <boost/ref.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/mpl/logical.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/type_traits/alignment_of.hpp>

--- a/include/boost/function/function_template.hpp
+++ b/include/boost/function/function_template.hpp
@@ -717,9 +717,9 @@ namespace boost {
     template<typename Functor>
     BOOST_FUNCTION_FUNCTION(Functor BOOST_FUNCTION_TARGET_FIX(const &) f
 #ifndef BOOST_NO_SFINAE
-                            ,typename enable_if_c<
-                            (boost::type_traits::ice_not<
-                             (is_integral<Functor>::value)>::value),
+                            ,typename enable_if<
+                            typename boost::mpl::not_<
+                             is_integral<Functor> >::type,
                                         int>::type = 0
 #endif // BOOST_NO_SFINAE
                             ) :
@@ -730,9 +730,9 @@ namespace boost {
     template<typename Functor,typename Allocator>
     BOOST_FUNCTION_FUNCTION(Functor BOOST_FUNCTION_TARGET_FIX(const &) f, Allocator a
 #ifndef BOOST_NO_SFINAE
-                            ,typename enable_if_c<
-                            (boost::type_traits::ice_not<
-                             (is_integral<Functor>::value)>::value),
+                            ,typename enable_if<
+                            typename boost::mpl::not_<
+                              is_integral<Functor> >::type,
                                         int>::type = 0
 #endif // BOOST_NO_SFINAE
                             ) :
@@ -780,9 +780,9 @@ namespace boost {
     // construct.
     template<typename Functor>
 #ifndef BOOST_NO_SFINAE
-    typename enable_if_c<
-               (boost::type_traits::ice_not<
-                 (is_integral<Functor>::value)>::value),
+    typename enable_if<
+               typename boost::mpl::not_<
+                  is_integral<Functor> >::type,
                BOOST_FUNCTION_FUNCTION&>::type
 #else
     BOOST_FUNCTION_FUNCTION&
@@ -1068,9 +1068,9 @@ public:
   template<typename Functor>
   function(Functor f
 #ifndef BOOST_NO_SFINAE
-           ,typename enable_if_c<
-                            (boost::type_traits::ice_not<
-                          (is_integral<Functor>::value)>::value),
+           ,typename enable_if<
+                            typename boost::mpl::not_<
+                          is_integral<Functor> >::type,
                        int>::type = 0
 #endif
            ) :
@@ -1080,9 +1080,9 @@ public:
   template<typename Functor,typename Allocator>
   function(Functor f, Allocator a
 #ifndef BOOST_NO_SFINAE
-           ,typename enable_if_c<
-                            (boost::type_traits::ice_not<
-                          (is_integral<Functor>::value)>::value),
+           ,typename enable_if<
+                            typename boost::mpl::not_<
+                           is_integral<Functor> >::type,
                        int>::type = 0
 #endif
            ) :
@@ -1120,9 +1120,9 @@ public:
 
   template<typename Functor>
 #ifndef BOOST_NO_SFINAE
-  typename enable_if_c<
-                            (boost::type_traits::ice_not<
-                         (is_integral<Functor>::value)>::value),
+  typename enable_if<
+                            typename boost::mpl::not_<
+                         is_integral<Functor> >::type,
                       self_type&>::type
 #else
   self_type&


### PR DESCRIPTION
This change in Boost function headers removes the dependencies on the deprecated ice_xxx.hpp headers in type_traits.