### PR TITLE
Qualify enable_if with namespace boost

### DIFF
--- a/include/boost/function/function_template.hpp
+++ b/include/boost/function/function_template.hpp
@@ -717,7 +717,7 @@ namespace boost {
     template<typename Functor>
     BOOST_FUNCTION_FUNCTION(Functor BOOST_FUNCTION_TARGET_FIX(const &) f
 #ifndef BOOST_NO_SFINAE
-                            ,typename enable_if<
+                            ,typename boost::enable_if<
                             typename boost::mpl::not_<
                              is_integral<Functor> >::type,
                                         int>::type = 0
@@ -730,7 +730,7 @@ namespace boost {
     template<typename Functor,typename Allocator>
     BOOST_FUNCTION_FUNCTION(Functor BOOST_FUNCTION_TARGET_FIX(const &) f, Allocator a
 #ifndef BOOST_NO_SFINAE
-                            ,typename enable_if<
+                            ,typename boost::enable_if<
                             typename boost::mpl::not_<
                               is_integral<Functor> >::type,
                                         int>::type = 0
@@ -780,7 +780,7 @@ namespace boost {
     // construct.
     template<typename Functor>
 #ifndef BOOST_NO_SFINAE
-    typename enable_if<
+    typename boost::enable_if<
                typename boost::mpl::not_<
                   is_integral<Functor> >::type,
                BOOST_FUNCTION_FUNCTION&>::type
@@ -1068,7 +1068,7 @@ public:
   template<typename Functor>
   function(Functor f
 #ifndef BOOST_NO_SFINAE
-           ,typename enable_if<
+           ,typename boost::enable_if<
                             typename boost::mpl::not_<
                           is_integral<Functor> >::type,
                        int>::type = 0
@@ -1080,7 +1080,7 @@ public:
   template<typename Functor,typename Allocator>
   function(Functor f, Allocator a
 #ifndef BOOST_NO_SFINAE
-           ,typename enable_if<
+           ,typename boost::enable_if<
                             typename boost::mpl::not_<
                            is_integral<Functor> >::type,
                        int>::type = 0
@@ -1120,7 +1120,7 @@ public:
 
   template<typename Functor>
 #ifndef BOOST_NO_SFINAE
-  typename enable_if<
+  typename boost::enable_if<
                             typename boost::mpl::not_<
                          is_integral<Functor> >::type,
                       self_type&>::type


### PR DESCRIPTION
Unfortunately the change from enable_if_c to enable_if in 74c9cc968086e25b6b63342528dd8f3e7f13fa2d broke a lot of other libraries' regression tests on MSVC, which complains about ambiguous symbols.

The failures are visible in http://www.boost.org/development/tests/develop/developer/output/teeks99-08e-win2012R2-64on64-boost-bin-v2-libs-test-test-single_header_test-test-msvc-12-0-dbg-adrs-mdl-64-archt-x86-thrd-mlt.html, for example.