### PR TITLE
Use Boost.TypeIndex to work with type_info to avoid bunch of ...

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -128,7 +128,7 @@
 
       <method name="target_type" cv="const">
         <type>const std::type_info&amp;</type>
-        <returns><simpara><code>typeid</code> of the target function object, or <code>typeid(void)</code> if <code>this-&gt;<methodname>empty</methodname>()</code>.</simpara></returns>
+        <returns><simpara><code>typeid</code> of the target function object, or <code>typeid(void)</code> if <code>this-&gt;<methodname>empty</methodname>()</code>. Works even with RTTI off.</simpara></returns>
         <throws><simpara>Will not throw.</simpara></throws>
       </method>
     </method-group>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -21,6 +21,8 @@ import testing ;
     : 
   [ run libs/function/test/function_test.cpp :  :  :  : lib_function_test ]
 
+  [ run libs/function/test/function_test.cpp :  :  : <rtti>off : lib_function_test_no_rtti ]
+
   [ run libs/function/test/function_n_test.cpp :  :  :  :  ]
 
   [ run libs/function/test/allocator_test.cpp ../../../libs/test/build//boost_test_exec_monitor :  :  :  :  ]


### PR DESCRIPTION
... non-optimal and outdated workarounds, operations, macro calls. Added RTTI-off tests.