### PR TITLE
Use ! operator directly rather than boost::mpl::not with Boost supported...

### DIFF
--- a/include/boost/function/function_base.hpp
+++ b/include/boost/function/function_base.hpp
@@ -71,19 +71,10 @@
 #  define BOOST_FUNCTION_TARGET_FIX(x)
 #endif // __ICL etc
 
-#if !BOOST_WORKAROUND(__BORLANDC__, < 0x5A0)
 #  define BOOST_FUNCTION_ENABLE_IF_NOT_INTEGRAL(Functor,Type)              \
       typename ::boost::enable_if_c<          \
                            !(::boost::is_integral<Functor>::value), \
                            Type>::type
-#else
-// BCC doesn't recognize this depends on a template argument and complains
-// about the use of 'typename'
-#  define BOOST_FUNCTION_ENABLE_IF_NOT_INTEGRAL(Functor,Type)     \
-      ::boost::enable_if_c<          \
-                   !(::boost::is_integral<Functor>::value), \
-                       Type>::type
-#endif
 
 namespace boost {
   namespace detail {

--- a/include/boost/function/function_base.hpp
+++ b/include/boost/function/function_base.hpp
@@ -27,7 +27,6 @@
 #include <boost/type_traits/composite_traits.hpp>
 #include <boost/ref.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/mpl/not.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/type_traits/alignment_of.hpp>
 #ifndef BOOST_NO_SFINAE
@@ -74,15 +73,15 @@
 
 #if !BOOST_WORKAROUND(__BORLANDC__, < 0x5A0)
 #  define BOOST_FUNCTION_ENABLE_IF_NOT_INTEGRAL(Functor,Type)              \
-      typename ::boost::enable_if<typename ::boost::mpl::not_<          \
-                            ::boost::is_integral<Functor> >::type, \
+      typename ::boost::enable_if_c<          \
+                           !(::boost::is_integral<Functor>::value), \
                            Type>::type
 #else
 // BCC doesn't recognize this depends on a template argument and complains
 // about the use of 'typename'
 #  define BOOST_FUNCTION_ENABLE_IF_NOT_INTEGRAL(Functor,Type)     \
-      ::boost::enable_if<::boost::mpl::not_<          \
-                   ::boost::is_integral<Functor> >::type, \
+      ::boost::enable_if_c<          \
+                   !(::boost::is_integral<Functor>::value), \
                        Type>::type
 #endif
 

--- a/include/boost/function/function_template.hpp
+++ b/include/boost/function/function_template.hpp
@@ -717,9 +717,8 @@ namespace boost {
     template<typename Functor>
     BOOST_FUNCTION_FUNCTION(Functor BOOST_FUNCTION_TARGET_FIX(const &) f
 #ifndef BOOST_NO_SFINAE
-                            ,typename boost::enable_if<
-                            typename boost::mpl::not_<
-                             is_integral<Functor> >::type,
+                            ,typename boost::enable_if_c<
+                             !(is_integral<Functor>::value),
                                         int>::type = 0
 #endif // BOOST_NO_SFINAE
                             ) :
@@ -730,9 +729,8 @@ namespace boost {
     template<typename Functor,typename Allocator>
     BOOST_FUNCTION_FUNCTION(Functor BOOST_FUNCTION_TARGET_FIX(const &) f, Allocator a
 #ifndef BOOST_NO_SFINAE
-                            ,typename boost::enable_if<
-                            typename boost::mpl::not_<
-                              is_integral<Functor> >::type,
+                            ,typename boost::enable_if_c<
+                              !(is_integral<Functor>::value),
                                         int>::type = 0
 #endif // BOOST_NO_SFINAE
                             ) :
@@ -780,9 +778,8 @@ namespace boost {
     // construct.
     template<typename Functor>
 #ifndef BOOST_NO_SFINAE
-    typename boost::enable_if<
-               typename boost::mpl::not_<
-                  is_integral<Functor> >::type,
+    typename boost::enable_if_c<
+                  !(is_integral<Functor>::value),
                BOOST_FUNCTION_FUNCTION&>::type
 #else
     BOOST_FUNCTION_FUNCTION&
@@ -1068,9 +1065,8 @@ public:
   template<typename Functor>
   function(Functor f
 #ifndef BOOST_NO_SFINAE
-           ,typename boost::enable_if<
-                            typename boost::mpl::not_<
-                          is_integral<Functor> >::type,
+           ,typename boost::enable_if_c<
+                          !(is_integral<Functor>::value),
                        int>::type = 0
 #endif
            ) :
@@ -1080,9 +1076,8 @@ public:
   template<typename Functor,typename Allocator>
   function(Functor f, Allocator a
 #ifndef BOOST_NO_SFINAE
-           ,typename boost::enable_if<
-                            typename boost::mpl::not_<
-                           is_integral<Functor> >::type,
+           ,typename boost::enable_if_c<
+                           !(is_integral<Functor>::value),
                        int>::type = 0
 #endif
            ) :
@@ -1120,9 +1115,8 @@ public:
 
   template<typename Functor>
 #ifndef BOOST_NO_SFINAE
-  typename boost::enable_if<
-                            typename boost::mpl::not_<
-                         is_integral<Functor> >::type,
+  typename boost::enable_if_c<
+                         !(is_integral<Functor>::value),
                       self_type&>::type
 #else
   self_type&


### PR DESCRIPTION
Changed at suggestion of John Maddock to use C++ operators directly for current Boost supported compilers rather than use equivalent boost::mpl constructs, when eliminating dependency on deprecated type_traits ice_xxx.hpp headers.