### PR TITLE
Suppress weak vtables warning

### DIFF
--- a/include/boost/function/function_base.hpp
+++ b/include/boost/function/function_base.hpp
@@ -689,6 +689,10 @@ public: // should be protected, but GCC 2.95.3 will fail to allow access
   mutable detail::function::function_buffer functor;
 };
 
+#if defined(BOOST_CLANG)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
 /**
  * The bad_function_call exception class is thrown when a boost::function
  * object is invoked
@@ -698,6 +702,9 @@ class bad_function_call : public std::runtime_error
 public:
   bad_function_call() : std::runtime_error("call to empty boost::function") {}
 };
+#if defined(BOOST_CLANG)
+#   pragma clang diagnostic pop
+#endif
 
 #ifndef BOOST_NO_SFINAE
 inline bool operator==(const function_base& f,


### PR DESCRIPTION
Fixes following warning:

```
In file included from qi/actions2.cpp:20:
In file included from ../../../boost/spirit/include/qi.hpp:16:
In file included from ../../../boost/spirit/home/qi.hpp:21:
In file included from ../../../boost/spirit/home/qi/nonterminal.hpp:14:
In file included from ../../../boost/spirit/home/qi/nonterminal/rule.hpp:16:
In file included from ../../../boost/function.hpp:24:
In file included from ../../../boost/function/detail/prologue.hpp:17:
../../../boost/function/function_base.hpp:696:7: warning: 'bad_function_call' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Wweak-vtables]
class bad_function_call : public std::runtime_error
      ^
```
