### PR TITLE
Conditionally disable tests using deprecated/removed C++98 binders.

### DIFF
--- a/test/std_bind_cxx98.cpp
+++ b/test/std_bind_cxx98.cpp
@@ -20,11 +20,12 @@ int X::foo(int x) { return -x; }
 
 int main()
 {
+#ifndef BOOST_NO_CXX98_BINDERS
       boost::function<int (int)> f;
   X x;
   f = std::bind1st(
         std::mem_fun(&X::foo), &x);
   f(5); // Call x.foo(5)
-
+#endif
     return 0;
 }

--- a/test/std_bind_portable.cpp
+++ b/test/std_bind_portable.cpp
@@ -20,11 +20,12 @@ int X::foo(int x) { return -x; }
 
 int main()
 {
+#ifndef BOOST_NO_CXX98_BINDERS
       boost::function1<int, int> f;
   X x;
   f = std::bind1st(
         std::mem_fun(&X::foo), &x);
   f(5); // Call x.foo(5)
-
+#endif
     return 0;
 }


### PR DESCRIPTION
Signed-off-by: Daniela Engert <dani@ngrt.de>