### PR TITLE
Add missing include guards to speed up compilation

### DIFF
--- a/include/boost/function.hpp
+++ b/include/boost/function.hpp
@@ -9,6 +9,8 @@
 
 // William Kempf, Jesse Jones and Karl Nelson were all very helpful in the
 // design of this library.
+#ifndef BOOST_FUNCTION_HPP
+#define BOOST_FUNCTION_HPP
 
 #include <functional> // unary_function, binary_function
 
@@ -64,3 +66,5 @@
 #  include BOOST_PP_ITERATE()
 #  undef BOOST_PP_ITERATION_PARAMS_1
 #endif
+
+#endif // BOOST_FUNCTION_HPP

--- a/include/boost/function.hpp
+++ b/include/boost/function.hpp
@@ -9,62 +9,19 @@
 
 // William Kempf, Jesse Jones and Karl Nelson were all very helpful in the
 // design of this library.
-#ifndef BOOST_FUNCTION_HPP
-#define BOOST_FUNCTION_HPP
 
-#include <functional> // unary_function, binary_function
+// No include guards to allow include again with bigger
+// BOOST_FUNCTION_MAX_ARGS
 
-#include <boost/preprocessor/iterate.hpp>
-#include <boost/detail/workaround.hpp>
-
-#ifndef BOOST_FUNCTION_MAX_ARGS
-#  define BOOST_FUNCTION_MAX_ARGS 10
-#endif // BOOST_FUNCTION_MAX_ARGS
-
-// Include the prologue here so that the use of file-level iteration
-// in anything that may be included by function_template.hpp doesn't break
-#include <boost/function/detail/prologue.hpp>
-
-// Older Visual Age C++ version do not handle the file iteration well
-#if BOOST_WORKAROUND(__IBMCPP__, >= 500) && BOOST_WORKAROUND(__IBMCPP__, < 800)
-#  if BOOST_FUNCTION_MAX_ARGS >= 0
-#    include <boost/function/function0.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 1
-#    include <boost/function/function1.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 2
-#    include <boost/function/function2.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 3
-#    include <boost/function/function3.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 4
-#    include <boost/function/function4.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 5
-#    include <boost/function/function5.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 6
-#    include <boost/function/function6.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 7
-#    include <boost/function/function7.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 8
-#    include <boost/function/function8.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 9
-#    include <boost/function/function9.hpp>
-#  endif
-#  if BOOST_FUNCTION_MAX_ARGS >= 10
-#    include <boost/function/function10.hpp>
-#  endif
+#ifndef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#  include <boost/function/detail/function_expand.hpp>
 #else
-// What is the '3' for?
-#  define BOOST_PP_ITERATION_PARAMS_1 (3,(0,BOOST_FUNCTION_MAX_ARGS,<boost/function/detail/function_iterate.hpp>))
-#  include BOOST_PP_ITERATE()
-#  undef BOOST_PP_ITERATION_PARAMS_1
+#  ifndef BOOST_FUNCTION_MAX_ARGS
+#    include <boost/function/detail/function_expand.hpp>
+#  else
+#    if BOOST_FUNCTION_MAX_ARGS > BOOST_FUNCTION_MAX_ARGS_DEFINED
+#      include <boost/function/detail/function_expand.hpp>
+#    endif
+#  endif
 #endif
 
-#endif // BOOST_FUNCTION_HPP

--- a/include/boost/function/detail/function_expand.hpp
+++ b/include/boost/function/detail/function_expand.hpp
@@ -1,0 +1,91 @@
+// Boost.Function library
+
+//  Copyright Douglas Gregor 2001-2003. Use, modification and
+//  distribution is subject to the Boost Software License, Version
+//  1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+// For more information, see http://www.boost.org/libs/function
+
+// William Kempf, Jesse Jones and Karl Nelson were all very helpful in the
+// design of this library.
+
+// No include guards to allow include again with different
+// BOOST_FUNCTION_MAX_ARGS
+
+#include <functional> // unary_function, binary_function
+
+#include <boost/preprocessor/iterate.hpp>
+#include <boost/detail/workaround.hpp>
+
+#ifndef BOOST_FUNCTION_MAX_ARGS
+#  define BOOST_FUNCTION_MAX_ARGS 10
+#endif // BOOST_FUNCTION_MAX_ARGS
+
+// Include the prologue here so that the use of file-level iteration
+// in anything that may be included by function_template.hpp doesn't break
+#include <boost/function/detail/prologue.hpp>
+
+// Older Visual Age C++ version do not handle the file iteration well
+#if BOOST_WORKAROUND(__IBMCPP__, >= 500) && BOOST_WORKAROUND(__IBMCPP__, < 800)
+#  if BOOST_FUNCTION_MAX_ARGS >= 0
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 0
+#    include <boost/function/function0.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 1
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 1
+#    include <boost/function/function1.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 2
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 2
+#    include <boost/function/function2.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 3
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 3
+#    include <boost/function/function3.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 4
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 4
+#    include <boost/function/function4.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 5
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 5
+#    include <boost/function/function5.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 6
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 6
+#    include <boost/function/function6.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 7
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 7
+#    include <boost/function/function7.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 8
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 8
+#    include <boost/function/function8.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 9
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 9
+#    include <boost/function/function9.hpp>
+#  endif
+#  if BOOST_FUNCTION_MAX_ARGS >= 10
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 10
+#    include <boost/function/function10.hpp>
+#  endif
+#else
+// What is the '3' for?
+#  define BOOST_PP_ITERATION_PARAMS_1 (3,(0,BOOST_FUNCTION_MAX_ARGS,<boost/function/detail/function_iterate.hpp>))
+#  include BOOST_PP_ITERATE()
+#  undef BOOST_PP_ITERATION_PARAMS_1
+#endif

--- a/include/boost/function/detail/gen_maybe_include.pl
+++ b/include/boost/function/detail/gen_maybe_include.pl
@@ -29,6 +29,8 @@ for($on_arg = 0; $on_arg <= $max_args; ++$on_arg) {
     print OUT " BOOST_FUNCTION_NUM_ARGS == $on_arg\n";
     print OUT "#  ifndef BOOST_FUNCTION_$on_arg\n";
     print OUT "#    define BOOST_FUNCTION_$on_arg\n";
+    print OUT "#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED\n";
+    print OUT "#    define BOOST_FUNCTION_MAX_ARGS_DEFINED $on_arg\n";
     print OUT "#    include <boost/function/function_template.hpp>\n";
     print OUT "#  endif\n";
 }

--- a/include/boost/function/detail/maybe_include.hpp
+++ b/include/boost/function/detail/maybe_include.hpp
@@ -1,265 +1,358 @@
-// Boost.Function library
-
-//  Copyright Douglas Gregor 2003. Use, modification and
-//  distribution is subject to the Boost Software License, Version
-//  1.0. (See accompanying file LICENSE_1_0.txt or copy at
-//  http://www.boost.org/LICENSE_1_0.txt)
-
-// For more information, see http://www.boost.org
-
 #if BOOST_FUNCTION_NUM_ARGS == 0
 #  ifndef BOOST_FUNCTION_0
 #    define BOOST_FUNCTION_0
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 0
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 1
 #  ifndef BOOST_FUNCTION_1
 #    define BOOST_FUNCTION_1
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 1
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 2
 #  ifndef BOOST_FUNCTION_2
 #    define BOOST_FUNCTION_2
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 2
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 3
 #  ifndef BOOST_FUNCTION_3
 #    define BOOST_FUNCTION_3
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 3
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 4
 #  ifndef BOOST_FUNCTION_4
 #    define BOOST_FUNCTION_4
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 4
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 5
 #  ifndef BOOST_FUNCTION_5
 #    define BOOST_FUNCTION_5
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 5
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 6
 #  ifndef BOOST_FUNCTION_6
 #    define BOOST_FUNCTION_6
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 6
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 7
 #  ifndef BOOST_FUNCTION_7
 #    define BOOST_FUNCTION_7
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 7
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 8
 #  ifndef BOOST_FUNCTION_8
 #    define BOOST_FUNCTION_8
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 8
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 9
 #  ifndef BOOST_FUNCTION_9
 #    define BOOST_FUNCTION_9
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 9
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 10
 #  ifndef BOOST_FUNCTION_10
 #    define BOOST_FUNCTION_10
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 10
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 11
 #  ifndef BOOST_FUNCTION_11
 #    define BOOST_FUNCTION_11
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 11
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 12
 #  ifndef BOOST_FUNCTION_12
 #    define BOOST_FUNCTION_12
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 12
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 13
 #  ifndef BOOST_FUNCTION_13
 #    define BOOST_FUNCTION_13
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 13
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 14
 #  ifndef BOOST_FUNCTION_14
 #    define BOOST_FUNCTION_14
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 14
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 15
 #  ifndef BOOST_FUNCTION_15
 #    define BOOST_FUNCTION_15
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 15
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 16
 #  ifndef BOOST_FUNCTION_16
 #    define BOOST_FUNCTION_16
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 16
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 17
 #  ifndef BOOST_FUNCTION_17
 #    define BOOST_FUNCTION_17
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 17
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 18
 #  ifndef BOOST_FUNCTION_18
 #    define BOOST_FUNCTION_18
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 18
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 19
 #  ifndef BOOST_FUNCTION_19
 #    define BOOST_FUNCTION_19
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 19
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 20
 #  ifndef BOOST_FUNCTION_20
 #    define BOOST_FUNCTION_20
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 20
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 21
 #  ifndef BOOST_FUNCTION_21
 #    define BOOST_FUNCTION_21
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 21
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 22
 #  ifndef BOOST_FUNCTION_22
 #    define BOOST_FUNCTION_22
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 22
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 23
 #  ifndef BOOST_FUNCTION_23
 #    define BOOST_FUNCTION_23
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 23
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 24
 #  ifndef BOOST_FUNCTION_24
 #    define BOOST_FUNCTION_24
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 24
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 25
 #  ifndef BOOST_FUNCTION_25
 #    define BOOST_FUNCTION_25
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 25
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 26
 #  ifndef BOOST_FUNCTION_26
 #    define BOOST_FUNCTION_26
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 26
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 27
 #  ifndef BOOST_FUNCTION_27
 #    define BOOST_FUNCTION_27
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 27
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 28
 #  ifndef BOOST_FUNCTION_28
 #    define BOOST_FUNCTION_28
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 28
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 29
 #  ifndef BOOST_FUNCTION_29
 #    define BOOST_FUNCTION_29
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 29
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 30
 #  ifndef BOOST_FUNCTION_30
 #    define BOOST_FUNCTION_30
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 30
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 31
 #  ifndef BOOST_FUNCTION_31
 #    define BOOST_FUNCTION_31
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 31
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 32
 #  ifndef BOOST_FUNCTION_32
 #    define BOOST_FUNCTION_32
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 32
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 33
 #  ifndef BOOST_FUNCTION_33
 #    define BOOST_FUNCTION_33
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 33
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 34
 #  ifndef BOOST_FUNCTION_34
 #    define BOOST_FUNCTION_34
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 34
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 35
 #  ifndef BOOST_FUNCTION_35
 #    define BOOST_FUNCTION_35
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 35
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 36
 #  ifndef BOOST_FUNCTION_36
 #    define BOOST_FUNCTION_36
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 36
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 37
 #  ifndef BOOST_FUNCTION_37
 #    define BOOST_FUNCTION_37
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 37
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 38
 #  ifndef BOOST_FUNCTION_38
 #    define BOOST_FUNCTION_38
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 38
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 39
 #  ifndef BOOST_FUNCTION_39
 #    define BOOST_FUNCTION_39
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 39
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 40
 #  ifndef BOOST_FUNCTION_40
 #    define BOOST_FUNCTION_40
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 40
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 41
 #  ifndef BOOST_FUNCTION_41
 #    define BOOST_FUNCTION_41
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 41
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 42
 #  ifndef BOOST_FUNCTION_42
 #    define BOOST_FUNCTION_42
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 42
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 43
 #  ifndef BOOST_FUNCTION_43
 #    define BOOST_FUNCTION_43
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 43
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 44
 #  ifndef BOOST_FUNCTION_44
 #    define BOOST_FUNCTION_44
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 44
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 45
 #  ifndef BOOST_FUNCTION_45
 #    define BOOST_FUNCTION_45
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 45
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 46
 #  ifndef BOOST_FUNCTION_46
 #    define BOOST_FUNCTION_46
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 46
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 47
 #  ifndef BOOST_FUNCTION_47
 #    define BOOST_FUNCTION_47
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 47
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 48
 #  ifndef BOOST_FUNCTION_48
 #    define BOOST_FUNCTION_48
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 48
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 49
 #  ifndef BOOST_FUNCTION_49
 #    define BOOST_FUNCTION_49
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 49
 #    include <boost/function/function_template.hpp>
 #  endif
 #elif BOOST_FUNCTION_NUM_ARGS == 50
 #  ifndef BOOST_FUNCTION_50
 #    define BOOST_FUNCTION_50
+#    undef BOOST_FUNCTION_MAX_ARGS_DEFINED
+#    define BOOST_FUNCTION_MAX_ARGS_DEFINED 50
 #    include <boost/function/function_template.hpp>
 #  endif
 #else


### PR DESCRIPTION
Even if function.hpp is in the precompiled header, without these
include guards, we pay the cost of pre-processing using boost pp.
This can be prohibitive with interactive parsing tools.

Test:
Apply update locally without rebuilding boost:
 - rebuild large project that uses boost function using Visual Studio 2017.
 - verify using the '/showincludes' option that we only pre-process boost function in the pre-compiled header.

Fixes: https://svn.boost.org/trac10/ticket/13105