### PR TITLE
Add minimal test for UBSan failures

### DIFF
--- a/test/ubsan_undefined_bug/Jamfile
+++ b/test/ubsan_undefined_bug/Jamfile
@@ -1,0 +1,18 @@
+import testing ;
+
+variant ubsan_undefined
+    : release
+    :
+    <cxxflags>"-std=c++11 -Wno-unused -fstrict-aliasing -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined"
+    <linkflags>"-fsanitize=undefined"
+    <debug-symbols>on
+    <define>BOOST_USE_ASAN=1
+    ;
+
+project
+    : requirements
+    <include>$(BOOST_ROOT)
+    <library>/boost/test//boost_unit_test_framework
+    ;
+
+run test.cpp ;

--- a/test/ubsan_undefined_bug/test.cpp
+++ b/test/ubsan_undefined_bug/test.cpp
@@ -1,0 +1,11 @@
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE( ubsan_tests )
+
+BOOST_AUTO_TEST_CASE( test1 )
+{
+    BOOST_CHECK(true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
_(this is an issue report but with mwe to reproduce it as per @pdimov suggestion on Slack)_

Reproduced with clang 5.0 and 6.0 on Linux using Boost super-project at `master` as well as Function at `develop`:

```shell
cd libs/function/test/ubsan_undefined_bug
b2 toolset=clang variant=ubsan_undefined
```

-----

Full log:

```shell
$ b2 toolset=clang variant=ubsan_undefined
Performing configuration checks

    - default address-model    : 64-bit
    - default architecture     : x86
    - symlinks supported       : yes
    - BOOST_COMP_GNUC >= 4.3.0 : no
...patience...
...found 2941 targets...
...updating 61 targets...
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/system/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/error_code.o
clang-linux.link.dll ../../../../bin.v2/libs/system/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/libboost_system.so.1.69.0
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/timer/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/auto_timers_construction.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/chrono/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/chrono.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/chrono/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/thread_clock.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/compiler_log_formatter.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/debug.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/chrono/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/process_cpu_clocks.o
clang-linux.link.dll ../../../../bin.v2/libs/chrono/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/libboost_chrono.so.1.69.0
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/timer/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/cpu_timer.o
clang-linux.link.dll ../../../../bin.v2/libs/timer/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/libboost_timer.so.1.69.0
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/plain_report_formatter.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/progress_monitor.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/decorator.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/execution_monitor.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test_framework_init_observer.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/results_collector.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/results_reporter.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/unit_test_monitor.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test_tools.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/unit_test_main.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/unit_test_log.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test_tree.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/xml_log_formatter.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/xml_report_formatter.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/framework.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/junit_log_formatter.o
clang-linux.compile.c++.without-pth ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/unit_test_parameters.o
clang-linux.link.dll ../../../../bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/libboost_unit_test_framework.so.1.69.0
clang-linux.link ../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test
testing.capture-output ../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.run
====== BEGIN OUTPUT ======
../../../../boost/function/function_template.hpp:768:14: runtime error: call to function (unknown) through pointer to incorrect function type 'void (*)(boost::detail::function::function_buffer &)'
(/mnt/d/boost.wsl/bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test+0x42cf60): note: (unknown) defined here

EXIT STATUS: 1
====== END OUTPUT ======

    LD_LIBRARY_PATH="/mnt/d/boost.wsl/bin.v2/libs/chrono/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden:/mnt/d/boost.wsl/bin.v2/libs/system/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden:/mnt/d/boost.wsl/bin.v2/libs/test/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden:/mnt/d/boost.wsl/bin.v2/libs/timer/build/clang-linux-6.0.0/ubsan_undefined/visibility-hidden:$LD_LIBRARY_PATH"
export LD_LIBRARY_PATH

    status=0
    if test $status -ne 0 ; then
        echo Skipping test execution due to testing.execute=off
        exit 0
    fi
     "../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test"   > "../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.output" 2>&1 < /dev/null
    status=$?
    echo >> "../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.output"
    echo EXIT STATUS: $status >> "../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.output"
    if test $status -eq 0 ; then
        cp "../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.output" "../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.run"
    fi
    verbose=0
    if test $status -ne 0 ; then
        verbose=1
    fi
    if test $verbose -eq 1 ; then
        echo ====== BEGIN OUTPUT ======
        cat "../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.output"
        echo ====== END OUTPUT ======
    fi
    exit $status

...failed testing.capture-output ../../../../bin.v2/libs/function/test/ubsan_undefined_bug/test.test/clang-linux-6.0.0/ubsan_undefined/visibility-hidden/test.run...
...failed updating 1 target...
...skipped 1 target...
...updated 59 targets...
mloskot@bionic:/mnt/d/boost.wsl/libs/function/test/ubsan_undefined_bug$
```

Originally, the issue was discovered while running Boost.GIL tests.