### PR TITLE
Forgot to undef BOOST_FUNCTION_NUM_ARGS

### DIFF
--- a/include/boost/function.hpp
+++ b/include/boost/function.hpp
@@ -31,6 +31,7 @@
 
 #ifndef BOOST_FUNCTION_NO_VARIADIC
 #  include <boost/function/detail/maybe_include.hpp>
+#  undef BOOST_FUNCTION_NUM_ARGS
 // Older Visual Age C++ version do not handle the file iteration well
 #elif BOOST_WORKAROUND(__IBMCPP__, >= 500) && BOOST_WORKAROUND(__IBMCPP__, < 800)
 #  if BOOST_FUNCTION_MAX_ARGS >= 0


### PR DESCRIPTION
Fixes macro redefinition warning from:
```cpp
#include <boost/function.hpp>
#include <boost/function/function0.hpp>
```