### PR TITLE
Silence `-Wuninitialized` warnings in GCC 12

### DIFF
--- a/include/boost/function/function_template.hpp
+++ b/include/boost/function/function_template.hpp
@@ -906,10 +906,18 @@ namespace boost {
             // This warning is technically correct, but we don't want to pay the price for initializing
             // just to silence a warning: https://github.com/boostorg/function/issues/27
 #           pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#           if (BOOST_GCC >= 120000)
+#             pragma GCC diagnostic push
+              // GCC 12 emits a different warning: https://github.com/boostorg/function/issues/42
+#             pragma GCC diagnostic ignored "-Wuninitialized"
+#           endif
 #         endif
           std::memcpy(this->functor.data, f.functor.data, sizeof(boost::detail::function::function_buffer));
 #         if defined(BOOST_GCC) && (BOOST_GCC >= 40700)
 #           pragma GCC diagnostic pop
+#           if (BOOST_GCC >= 120000)
+#             pragma GCC diagnostic pop
+#           endif
 #         endif
         } else
           get_vtable()->base.manager(f.functor, this->functor,
@@ -1004,10 +1012,18 @@ namespace boost {
               // This warning is technically correct, but we don't want to pay the price for initializing
               // just to silence a warning: https://github.com/boostorg/function/issues/27
 #             pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#             if (BOOST_GCC >= 120000)
+#               pragma GCC diagnostic push
+                // GCC 12 emits a different warning: https://github.com/boostorg/function/issues/42
+#               pragma GCC diagnostic ignored "-Wuninitialized"
+#             endif
 #           endif
             std::memcpy(this->functor.data, f.functor.data, sizeof(this->functor.data));
 #           if defined(BOOST_GCC) && (BOOST_GCC >= 40700)
 #             pragma GCC diagnostic pop
+#             if (BOOST_GCC >= 120000)
+#               pragma GCC diagnostic pop
+#             endif
 #           endif
           } else
 #if defined(BOOST_GCC) && (__GNUC__ == 11)


### PR DESCRIPTION
Follow-up to #38 for GCC version 12. Fixes #42.