### PR TITLE
Fix issue documented in Debian bug #1059133

### DIFF
--- a/include/boost/function/function_base.hpp
+++ b/include/boost/function/function_base.hpp
@@ -649,7 +649,7 @@ public:
                       detail::function::check_functor_type_tag);
       // GCC 2.95.3 gets the CV qualifiers wrong here, so we
       // can't do the static_cast that we should do.
-      return static_cast<const Functor*>(type_result.members.obj_ptr);
+      return reinterpret_cast<const Functor*>(type_result.members.obj_ptr);
     }
 
   template<typename F>


### PR DESCRIPTION
I am surely out of my depth here, but this Works4Me™. See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1059133
I would love to get some feedback as to why I'm wrong and what this change might break elsewhere.

Full disclosure: I do not run Debian and I did not have _that_ exact issue, per se. I encountered an essentially identical error message (although I'd used -std=c++17) while building a FreeBSD port for https://github.com/BTCGPU/BTCGPU/releases/tag/v0.17.3 against boost-libs-1.83.0_1.pkg. A little Google-fu led me to the bug report linked above, sadly unresolved. I made this modification which I've proposed in this pull request to the devel/boost-libs port on my FreeBSD 13.2-RELEASE-p9/amd64 system in order to resolve the error and build Bitcoin Gold successfully. I then ran the daemon and command line utility exactly once, to liquidate my meager holdings in one wallet-sweeping transaction; so, by no means a thorough test of the software's functionality.

I'm sorry I didn't keep more detailed information for you. I just left the browser tab open to that Debian bug report because it is the _exact_ same error output I was getting. I had this diff to boost-libs laying around at the end of it so I figured the responsible thing to do would be to bring it up to the experts.