### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -13,10 +13,8 @@ project /boost/function
         <library>/boost/bind//boost_bind
         <library>/boost/config//boost_config
         <library>/boost/core//boost_core
-        <library>/boost/preprocessor//boost_preprocessor
         <library>/boost/throw_exception//boost_throw_exception
         <library>/boost/type_traits//boost_type_traits
-        <library>/boost/typeof//boost_typeof
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -5,21 +5,24 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/bind//boost_bind
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/function
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/bind//boost_bind
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_function ]
+    [ alias boost_function : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_function example test ]
     ;
 
 call-if : boost-library function
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,14 +7,14 @@ import project ;
 
 project /boost/function
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/bind//boost_bind
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/typeof//boost_typeof
+        <library>/boost/assert//boost_assert
+        <library>/boost/bind//boost_bind
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/typeof//boost_typeof
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/function

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,27 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/function
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/bind//boost_bind
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/typeof//boost_typeof
+        <include>include
+    ;
+
+explicit
+    [ alias boost_function ]
+    [ alias all : boost_function example test ]
+    ;
+
+call-if : boost-library function
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/function
     : common-requirements

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -11,6 +11,8 @@ import-search /boost/config/checks ;
 import config : requires ;
 import testing ;
 
+project : requirements <library>/boost/function//boost_function ;
+
 run bind1st.cpp : : : [ requires cxx98_binders ] ;
 run int_div.cpp ;
 run sum_avg.cpp ;

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -6,7 +6,9 @@
 # See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt
 
-import ../../config/checks/config : requires ;
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 import testing ;
 
 run bind1st.cpp : : : [ requires cxx98_binders ] ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -17,6 +17,7 @@ project
     <toolset>gcc:<warnings-as-errors>on
     <toolset>clang:<warnings-as-errors>on
     <library>/boost/typeof//boost_typeof
+    <library>/boost/function//boost_function
   ;
 
 run function_test.cpp ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -25,7 +25,7 @@ run function_test.cpp : : : <rtti>off <toolset>gcc-4.4,<cxxstd>0x:<build>no : fu
 run function_n_test.cpp ;
 run allocator_test.cpp ;
 run stateless_test.cpp ;
-run lambda_test.cpp : : : <source>/boost/lambda//boost_lambda ;
+run lambda_test.cpp : : : <library>/boost/lambda//boost_lambda ;
 compile-fail function_test_fail1.cpp ;
 compile-fail function_test_fail2.cpp ;
 compile function_30.cpp ;
@@ -43,7 +43,7 @@ run function_ref_portable.cpp ;
 run contains_test.cpp ;
 run contains2_test.cpp ;
 run nothrow_swap.cpp ;
-run rvalues_test.cpp : : : <source>/boost/move//boost_move ;
+run rvalues_test.cpp : : : <library>/boost/move//boost_move ;
 compile function_typeof_test.cpp
    : <cxxstd>03:<build>no <cxxstd>98:<build>no <cxxstd>0x:<build>no ;
 run result_arg_types_test.cpp ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,7 +24,7 @@ run function_test.cpp : : : <rtti>off <toolset>gcc-4.4,<cxxstd>0x:<build>no : fu
 run function_n_test.cpp ;
 run allocator_test.cpp ;
 run stateless_test.cpp ;
-run lambda_test.cpp ;
+run lambda_test.cpp : : : <source>/boost/lambda//boost_lambda ;
 compile-fail function_test_fail1.cpp ;
 compile-fail function_test_fail2.cpp ;
 compile function_30.cpp ;
@@ -42,7 +42,7 @@ run function_ref_portable.cpp ;
 run contains_test.cpp ;
 run contains2_test.cpp ;
 run nothrow_swap.cpp ;
-run rvalues_test.cpp ;
+run rvalues_test.cpp : : : <source>/boost/move//boost_move ;
 compile function_typeof_test.cpp
    : <cxxstd>03:<build>no <cxxstd>98:<build>no <cxxstd>0x:<build>no ;
 run result_arg_types_test.cpp ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -16,6 +16,7 @@ project
     <toolset>msvc:<warnings-as-errors>on
     <toolset>gcc:<warnings-as-errors>on
     <toolset>clang:<warnings-as-errors>on
+    <library>/boost/typeof//boost_typeof
   ;
 
 run function_test.cpp ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.