### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -20,7 +20,6 @@ throw_exception
 
 # Secondary dependencies
 
-static_assert
 )
 
 foreach(dep IN LISTS deps)


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.